### PR TITLE
Potential fix for code scanning alert no. 3: Database query built from user-controlled sources

### DIFF
--- a/backend/src/occasions/services/occasions.service.ts
+++ b/backend/src/occasions/services/occasions.service.ts
@@ -48,9 +48,15 @@ export class OccasionService {
 
   async updateOccasion(_id: string, updateOccasionDto: OccasionDto): Promise<Occasion> {
     try {
-      const updatedOccasion = await this.occasionModel.findByIdAndUpdate(_id, updateOccasionDto, {
-        new: true,
-      });
+      // Prevent NoSQL injection: reject any keys starting with '$'
+      if (Object.keys(updateOccasionDto).some(key => key.startsWith('$'))) {
+        throw new InternalServerErrorException('Invalid update object');
+      }
+      const updatedOccasion = await this.occasionModel.findByIdAndUpdate(
+        _id,
+        { $set: updateOccasionDto },
+        { new: true },
+      );
       if (!updatedOccasion) {
         throw new NotFoundException(`Occasion with ID ${_id} not found`);
       }


### PR DESCRIPTION
Potential fix for [https://github.com/liamgentile/GiveInstead/security/code-scanning/3](https://github.com/liamgentile/GiveInstead/security/code-scanning/3)

To fix this vulnerability, we must ensure that the update object passed to `findByIdAndUpdate` cannot contain dangerous MongoDB update operators. The best way to do this is to validate that `updateOccasionDto` is a plain object with only allowed fields and does not contain any keys starting with `$`. This can be done by checking for keys that start with `$` and rejecting the request if any are found. Alternatively, we can use the `$set` operator to wrap the update object, ensuring that all fields are treated as literal values and not as update operators. The recommended fix is to wrap `updateOccasionDto` in a `$set` operator when calling `findByIdAndUpdate`, and optionally add a runtime check to reject any keys starting with `$` for extra safety.

Edit the `updateOccasion` method in `backend/src/occasions/services/occasions.service.ts` to wrap the update object in `$set`, and add a check for keys starting with `$` to prevent operator injection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
