### PR TITLE
Potential fix for code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/backend/src/favourite-charities/services/favouriteCharities.service.ts
+++ b/backend/src/favourite-charities/services/favouriteCharities.service.ts
@@ -1,5 +1,5 @@
 import { Model } from 'mongoose';
-import { Injectable, Logger, NotFoundException, InternalServerErrorException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, InternalServerErrorException, BadRequestException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { CreateFavouriteCharityDto } from '../dto/createFavouriteCharity.dto';
 import { FavouriteCharity } from '../schemas/favouriteCharity.schema';
@@ -31,8 +31,12 @@ export class FavouriteCharitiesService {
     try {
       const { _id, note } = updateFavouriteCharityNoteDto;
 
+      if (typeof _id !== 'string') {
+        throw new BadRequestException('Invalid _id');
+      }
+
       const updatedCharity = await this.favouriteCharityModel.findOneAndUpdate(
-        { _id },
+        { _id: { $eq: _id } },
         { $set: { note } },
         { new: true },
       );


### PR DESCRIPTION
Potential fix for [https://github.com/liamgentile/GiveInstead/security/code-scanning/2](https://github.com/liamgentile/GiveInstead/security/code-scanning/2)

To fix this issue, we need to ensure that the `_id` used in the query is always treated as a literal value and not as a query object. The best way to do this in MongoDB is to use the `$eq` operator, which forces the value to be interpreted as a literal, not as a query object. Additionally, we should check that `_id` is a string before using it in the query. This can be done with a simple type check, and if the check fails, throw a `BadRequestException`. The change should be made in the `updateNote` method of `FavouriteCharitiesService` in `backend/src/favourite-charities/services/favouriteCharities.service.ts`. No new imports are needed, as `BadRequestException` is already available from `@nestjs/common`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
