### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Backend Tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/liamgentile/GiveInstead/security/code-scanning/1](https://github.com/liamgentile/GiveInstead/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to check out code and run tests, it only requires `contents: read` permission. The best way to do this is to add the following at the top level of the workflow (just after the `name` field and before `on:`), so it applies to all jobs in the workflow. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
